### PR TITLE
Simplify setting Tokenizer options, add docs and comments

### DIFF
--- a/src/ast/value.rs
+++ b/src/ast/value.rs
@@ -182,8 +182,27 @@ pub struct EscapeQuotedString<'a> {
     quote: char,
 }
 
+
 impl<'a> fmt::Display for EscapeQuotedString<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        // EscapeQuotedString doesn't know which mode of escape was
+        // chosen by the user. So this code must to correctly display
+        // strings without knowing if the strings are already escaped
+        // or not.
+        //
+        // If the quote symbol in the string is repeated twice, OR, if
+        // the quote symbol is after backslash, display all the chars
+        // without any escape. However, if the quote symbol is used
+        // just between usual chars, `fmt()` should display it twice."
+        //
+        // The following table has examples
+        //
+        // | original query | mode      | AST Node                                           | serialized   |
+        // | -------------  | --------- | -------------------------------------------------- | ------------ |
+        // | `"A""B""A"`    | no-escape | `DoubleQuotedString(String::from("A\"\"B\"\"A"))`  | `"A""B""A"`  |
+        // | `"A""B""A"`    | default   | `DoubleQuotedString(String::from("A\"B\"A"))`      | `"A""B""A"`  |
+        // | `"A\"B\"A"`    | no-escape | `DoubleQuotedString(String::from("A\\\"B\\\"A"))`  | `"A\"B\"A"`  |
+        // | `"A\"B\"A"`    | default   | `DoubleQuotedString(String::from("A\"B\"A"))`      | `"A""B""A"`  |
         let quote = self.quote;
         let mut previous_char = char::default();
         let mut peekable_chars = self.string.chars().peekable();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -195,10 +195,52 @@ impl std::error::Error for ParserError {}
 // By default, allow expressions up to this deep before erroring
 const DEFAULT_REMAINING_DEPTH: usize = 50;
 
-#[derive(Debug, Default, Clone, PartialEq, Eq)]
+/// Options that control how the [`Parser`] parses SQL text
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ParserOptions {
     pub trailing_commas: bool,
-    pub no_escape: bool,
+    /// Controls how literal values are unescaped. See
+    /// [`Tokenizer::with_unescape`] for more details.
+    pub unescape: bool,
+}
+
+impl Default for ParserOptions {
+    fn default() -> Self {
+        Self {
+            trailing_commas: false,
+            unescape: true,
+        }
+    }
+}
+
+impl ParserOptions {
+    /// Create a new [`ParserOptions`]
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Set if trailing commas are allowed.
+    ///
+    /// If this option is `false` (the default), the following SQL will
+    /// not parse. If the option is `true`, the SQL will parse.
+    ///
+    /// ```sql
+    ///  SELECT
+    ///   foo,
+    ///   bar,
+    ///  FROM baz
+    /// ```
+    pub fn with_trailing_commas(mut self, trailing_commas: bool) -> Self {
+        self.trailing_commas = trailing_commas;
+        self
+    }
+
+    /// Set if literal values are unescaped. Defaults to true. See
+    /// [`Tokenizer::with_unescape`] for more details.
+    pub fn with_unescape(mut self, unescape: bool) -> Self {
+        self.unescape = unescape;
+        self
+    }
 }
 
 pub struct Parser<'a> {
@@ -207,8 +249,9 @@ pub struct Parser<'a> {
     index: usize,
     /// The current dialect to use
     dialect: &'a dyn Dialect,
-    /// Additional options that allow you to mix & match behavior otherwise
-    /// constrained to certain dialects (e.g. trailing commas) and/or format of parse (e.g. no escape)
+    /// Additional options that allow you to mix & match behavior
+    /// otherwise constrained to certain dialects (e.g. trailing
+    /// commas) and/or format of parse (e.g. unescaping)
     options: ParserOptions,
     /// ensure the stack does not overflow by limiting recursion depth
     recursion_counter: RecursionCounter,
@@ -268,17 +311,20 @@ impl<'a> Parser<'a> {
     /// Specify additional parser options
     ///
     ///
-    /// [`Parser`] supports additional options ([`ParserOptions`]) that allow you to
-    /// mix & match behavior otherwise constrained to certain dialects (e.g. trailing
-    /// commas).
+    /// [`Parser`] supports additional options ([`ParserOptions`])
+    /// that allow you to mix & match behavior otherwise constrained
+    /// to certain dialects (e.g. trailing commas).
     ///
     /// Example:
     /// ```
     /// # use sqlparser::{parser::{Parser, ParserError, ParserOptions}, dialect::GenericDialect};
     /// # fn main() -> Result<(), ParserError> {
     /// let dialect = GenericDialect{};
+    /// let options = ParserOptions::new()
+    ///    .with_trailing_commas(true)
+    ///    .with_unescape(false);
     /// let result = Parser::new(&dialect)
-    ///   .with_options(ParserOptions { trailing_commas: true, no_escape: false })
+    ///   .with_options(options)
     ///   .try_with_sql("SELECT a, b, COUNT(*), FROM foo GROUP BY a, b,")?
     ///   .parse_statements();
     ///   assert!(matches!(result, Ok(_)));
@@ -318,9 +364,9 @@ impl<'a> Parser<'a> {
     /// See example on [`Parser::new()`] for an example
     pub fn try_with_sql(self, sql: &str) -> Result<Self, ParserError> {
         debug!("Parsing sql '{}'...", sql);
-        let tokenizer_options = TokenizerOptions::new().with_no_escape(self.options.no_escape);
-        let mut tokenizer = Tokenizer::new(self.dialect, sql, &tokenizer_options);
-        let tokens = tokenizer.tokenize()?;
+        let tokens = Tokenizer::new(self.dialect, sql)
+            .with_unescape(self.options.unescape)
+            .tokenize()?;
         Ok(self.with_tokens(tokens))
     }
 

--- a/tests/sqlparser_common.rs
+++ b/tests/sqlparser_common.rs
@@ -1031,10 +1031,11 @@ fn parse_escaped_single_quote_string_predicate_with_no_escape() {
 
     let ast = TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: true,
-            no_escape: true,
-        }),
+        options: Some(
+            ParserOptions::new()
+                .with_trailing_commas(true)
+                .with_unescape(false),
+        ),
     }
     .verified_only_select(sql);
 
@@ -7095,10 +7096,7 @@ fn parse_non_latin_identifiers() {
 fn parse_trailing_comma() {
     let trailing_commas = TestedDialects {
         dialects: vec![Box::new(GenericDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: true,
-            no_escape: false,
-        }),
+        options: Some(ParserOptions::new().with_trailing_commas(true)),
     };
 
     trailing_commas.one_statement_parses_to(

--- a/tests/sqlparser_mysql.rs
+++ b/tests/sqlparser_mysql.rs
@@ -485,7 +485,7 @@ fn parse_escaped_quote_identifiers_with_no_escape() {
             dialects: vec![Box::new(MySqlDialect {})],
             options: Some(ParserOptions {
                 trailing_commas: false,
-                no_escape: true
+                unescape: false,
             }),
         }
         .verified_stmt(sql),
@@ -564,10 +564,7 @@ fn parse_escaped_backticks_with_no_escape() {
     assert_eq!(
         TestedDialects {
             dialects: vec![Box::new(MySqlDialect {})],
-            options: Some(ParserOptions {
-                trailing_commas: false,
-                no_escape: true
-            }),
+            options: Some(ParserOptions::new().with_unescape(false)),
         }
         .verified_stmt(sql),
         Statement::Query(Box::new(Query {
@@ -652,10 +649,7 @@ fn parse_escaped_string_with_no_escape() {
     fn assert_mysql_query_value(sql: &str, quoted: &str) {
         let stmt = TestedDialects {
             dialects: vec![Box::new(MySqlDialect {})],
-            options: Some(ParserOptions {
-                trailing_commas: false,
-                no_escape: true,
-            }),
+            options: Some(ParserOptions::new().with_unescape(false)),
         }
         .one_statement_parses_to(sql, "");
 
@@ -688,78 +682,53 @@ fn parse_escaped_string_with_no_escape() {
 
 #[test]
 fn check_roundtrip_of_escaped_string() {
+    let options = Some(ParserOptions::new().with_unescape(false));
+
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT 'I\'m fine'"#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT 'I''m fine'"#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT 'I\\\'m fine'"#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT 'I\\\'m fine'"#);
 
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT "I\"m fine""#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT "I""m fine""#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT "I\\\"m fine""#);
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options: options.clone(),
     }
     .verified_stmt(r#"SELECT "I\\\"m fine""#);
 
     TestedDialects {
         dialects: vec![Box::new(MySqlDialect {})],
-        options: Some(ParserOptions {
-            trailing_commas: false,
-            no_escape: true,
-        }),
+        options,
     }
     .verified_stmt(r#"SELECT "I'm ''fine''""#);
 }

--- a/tests/sqlparser_snowflake.rs
+++ b/tests/sqlparser_snowflake.rs
@@ -55,9 +55,7 @@ fn test_snowflake_create_transient_table() {
 fn test_snowflake_single_line_tokenize() {
     let sql = "CREATE TABLE# this is a comment \ntable_1";
     let dialect = SnowflakeDialect {};
-    let option = TokenizerOptions::new().with_no_escape(false);
-    let mut tokenizer = Tokenizer::new(&dialect, sql, &option);
-    let tokens = tokenizer.tokenize().unwrap();
+    let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
 
     let expected = vec![
         Token::make_keyword("CREATE"),
@@ -73,9 +71,7 @@ fn test_snowflake_single_line_tokenize() {
     assert_eq!(expected, tokens);
 
     let sql = "CREATE TABLE // this is a comment \ntable_1";
-    let option = TokenizerOptions::new().with_no_escape(false);
-    let mut tokenizer = Tokenizer::new(&dialect, sql, &option);
-    let tokens = tokenizer.tokenize().unwrap();
+    let tokens = Tokenizer::new(&dialect, sql).tokenize().unwrap();
 
     let expected = vec![
         Token::make_keyword("CREATE"),


### PR DESCRIPTION
This is a proposal to get https://github.com/sqlparser-rs/sqlparser-rs/pull/870 merged into SQL parser.

The core escaping/unescaping logic and tests in https://github.com/sqlparser-rs/sqlparser-rs/pull/870 is very nice I think

I still worry about the various API changes to the parser and tokenizer. As we have gone back and forth on this PR and API several times and I really I want to help get this in, I am trying to take a more active hand in getting the API shaped up

This PR leaves the core unescaping logic alone and changes the API in this way:
1. Move the `with_no_escape` to a method on `Tokenizer` thus removing an API change that would cause significant downstream churn
2. Renamed `no_escape` to `unescape`, otherwise I was finding reasoning about the double negative challenging
3. Added doc comments with examples explaining how to use this feature

I made this into a PR here (targeting this PR)

What do you think?


cc @canalun 